### PR TITLE
Fix inverted GPDMA port allocation on SAI TX path

### DIFF
--- a/stm32n6570_discovery_audio.c
+++ b/stm32n6570_discovery_audio.c
@@ -3218,7 +3218,7 @@ static void SAI_MspInit(SAI_HandleTypeDef *hsai)
     dmaNodeConfig.Init.DestBurstLength                = 1;
     dmaNodeConfig.Init.Priority                       = DMA_HIGH_PRIORITY;
     dmaNodeConfig.Init.TransferEventMode              = DMA_TCEM_BLOCK_TRANSFER;
-    dmaNodeConfig.Init.TransferAllocatedPort          = DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT1;
+    dmaNodeConfig.Init.TransferAllocatedPort          = DMA_SRC_ALLOCATED_PORT1 | DMA_DEST_ALLOCATED_PORT0;
     /* Set node data handling parameters */
     dmaNodeConfig.DataHandlingConfig.DataExchange     = DMA_EXCHANGE_NONE;
     dmaNodeConfig.DataHandlingConfig.DataAlignment    = DMA_DATA_RIGHTALIGN_ZEROPADDED;


### PR DESCRIPTION
One-line fix for Issue #2 , see the issue for full analysis and measurements. Verified the file builds within the BSP, behavior-neutral for isolated transfers per the benchmark linked in the issue.